### PR TITLE
商品画像用のショートコードを追加

### DIFF
--- a/src/shortcodes/product/class-image.php
+++ b/src/shortcodes/product/class-image.php
@@ -45,7 +45,10 @@ class Image implements Shortcode_Interface {
 				$image_url = $product->thumbnail_image_url;
 				break;
 			default:
-				return '';
+				if ( ! self::is_request_for_other_image( $filtered_atts ) ) {
+					return '';
+				}
+				$image_url = self::extract_other_image( $container, $filtered_atts );
 				break;
 		}
 
@@ -63,5 +66,56 @@ class Image implements Shortcode_Interface {
 			$image_url,
 			$attributes
 		);
+	}
+
+	/**
+	 * @param array $filtered_atts
+	 * @return bool
+	 */
+	private static function is_request_for_other_image( $filtered_atts ) {
+		return preg_match( '/\Aother[0-9]+\z/', $filtered_atts['type'] ) === 1;
+	}
+
+	/**
+	 * @param string $other_image_type
+	 * @return int
+	 */
+	private static function extract_other_image_index( $other_image_type ) {
+		return (int) str_replace( 'other', '', $other_image_type );
+	}
+
+	/**
+	 * @param \stdClass $product
+	 * @param bool $is_mobile
+	 * @return array
+	 */
+	private static function extract_other_images( $product, $is_mobile ) {
+		$filtered_images = array_filter($product->images, function ( $image ) use ( $is_mobile ) {
+			if ( $is_mobile ) {
+				return $image['mobile'];
+			}
+
+			return ! $image['mobile'];
+		});
+
+		return array_values( $filtered_images );
+	}
+
+	/**
+	 * その他画像の URL を返す
+	 *
+	 * @param \Pimple\Container $container
+	 * @param array $filtered_atts
+	 * @return string
+	 */
+	private static function extract_other_image( $container, $filtered_atts ) {
+		$index = self::extract_other_image_index( $filtered_atts['type'] );
+		// TODO: wp_is_mobile() は #14 をマージしたら DI コンテナに置き換える. モバイルアクセスのテストを書く.
+		$other_images = self::extract_other_images(
+			$container['model.product_api']->fetch( $filtered_atts['product_id'] ),
+			wp_is_mobile()
+		);
+
+		return isset( $other_images[ $index - 1 ] ) ? $other_images[ $index - 1 ]['src'] : '';
 	}
 }

--- a/tests/src/shortcodes/product/class-image-test.php
+++ b/tests/src/shortcodes/product/class-image-test.php
@@ -19,6 +19,18 @@ class Image_Test extends \WP_UnitTestCase {
 			'product' => [
 				'id' => 123,
 				'image_url' => 'http://img01.shop-pro.jp/PAXXX/XXX/product/123.jpg',
+                'images' => [
+                    [
+                        'src' => 'http://img01.shop-pro.jp/PAXXX/XXX/product/123_other1.jpg',
+                        'position' => 1,
+                        'mobile' => false,
+                    ],
+                    [
+                        'src' => 'http://img01.shop-pro.jp/PAXXX/XXX/product/123_other2.jpg',
+                        'position' => 2,
+                        'mobile' => false,
+                    ],
+                ],
 			],
 		]);
 
@@ -184,4 +196,35 @@ class Image_Test extends \WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+     * @test
+     */
+    public function show_その他画像のタグを返す() {
+        $this->assertSame(
+            '<img src="http://img01.shop-pro.jp/PAXXX/XXX/product/123_other1.jpg" />',
+            Image::show(
+                $this->container,
+                [
+                    'product_id' => 123,
+                    'type' => 'other1',
+                ],
+                null,
+                null
+            )
+        );
+
+        $this->assertSame(
+            '<img src="http://img01.shop-pro.jp/PAXXX/XXX/product/123_other2.jpg" />',
+            Image::show(
+                $this->container,
+                [
+                    'product_id' => 123,
+                    'type' => 'other2',
+                ],
+                null,
+                null
+            )
+        );
+    }
 }


### PR DESCRIPTION
closes #17 

#### デフォルト

- [colormeshop_product_image product_id=117182895]
- `<img src="http://img01.shop-pro.jp/PAXXX/XXX/product/123.jpg" />`

#### img タグの属性を指定

- [colormeshop_product_image product_id=117182895 width=100 class="foo bar"]
- `<img src="http://img01.shop-pro.jp/PAXXX/XXX/product/123.jpg" width="100" class="foo bar" />`

#### サムネイル画像 ( `type="thumbnail"` )

- [colormeshop_product_image product_id=117182895 type="thumbnail"]
- `<img src="http://img01.shop-pro.jp/PAXXX/XXX/product/123_th.jpg" />`

#### その他画像 ( `type="otherN"` )

- [colormeshop_product_image product_id=117182895 type="other1"]