### PR TITLE
ページタイトルに商品名を反映する

### DIFF
--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -45,6 +45,33 @@ class Plugin {
 		add_shortcode( 'authentication_link', [ $this, 'show_authentication_link' ] );
 
 		add_action( 'wp_ajax_colormeshop_callback', [ $this, 'colormeshop_callback' ] );
+		add_filter( 'document_title_parts', [ $this, 'filter_title' ] );
+	}
+
+	/**
+	 * タイトルに商品情報を追加する
+	 *
+	 * @param array $title_parts
+	 * @return array
+	 */
+	public function filter_title( $title_parts ) {
+		if (
+			! $this->container['target_id']
+			|| ! $this->container['product_page_id']
+			|| ! is_page( $this->container['product_page_id'] )
+		) {
+			return $title_parts;
+		}
+
+		try {
+			$title_parts['title'] = $this->container['model.product_api']->fetch( $this->container['target_id'] )->name . ' - ' . $title_parts['title'];
+		} catch ( \RuntimeException $e ) {
+			if ( $this->container['WP_DEBUG_LOG'] ) {
+				error_log( 'タイトルのフィルタに失敗しました : ' . $e->getMessage() );
+			}
+		}
+
+		return $title_parts;
 	}
 
 	/**


### PR DESCRIPTION
closes #23 

`<title>ネットショップ - プラグインテスト</title>`
↓
`<title>商品名 - ネットショップ - プラグインテスト</title>`

[All in One SEO Pack](https://ja.wordpress.org/plugins/all-in-one-seo-pack/) が有効になっている場合はそちらが優先されるので、All in One SEO Pack の詳細設定で商品ページを除外設定する必要があります。

- 商品ページの URL を除外設定
![image](https://cloud.githubusercontent.com/assets/1885716/26721819/59d9f7d6-47c8-11e7-84a5-f47be3b26d06.png)

