### PR TITLE
動作条件を満たない場合にエラーメッセージを表示する

### DIFF
--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -8,7 +8,31 @@
  * Author URI: https://pepabo.com/
  * License: GPL2
  */
+if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
+	add_action( 'admin_notices', 'colormeshop_wp_plugin_requirements_error' );
+	return;
+}
+
 require_once( 'vendor/autoload.php' );
 
 $p = new \ColorMeShop\Plugin;
 $p->register();
+
+/**
+ * 動作条件に満たない場合のエラーメッセージを出力する
+ *
+ * @return void
+ */
+function colormeshop_wp_plugin_requirements_error() {
+	$v = PHP_VERSION;
+	echo <<<__EOS__
+<div class="error">
+	<p>
+		カラーミーショップ Wordpress プラグインは PHP5.6 以上が必要ですが、ご利用中のバージョンは <strong>{$v}</strong> です。<br />
+		現在、プラグインは動作を停止していますので、PHP のアップデート後に再度プラグインを有効化してください。<br />
+		ご利用お待ちしています！
+	</p>
+</div>
+__EOS__;
+
+}


### PR DESCRIPTION
- php5.6 未満の場合、エラーメッセージを表示
- php5.2 は対応できていません
  - `colormeshop-wp-plugin.php` に書かれてる名前空間がパースできず、エラーになってしまう
  - (未検証ですが、有効化する前に、プラグイン管理画面でエラーになると思います）

### プラグインを有効化した時にエラーメッセージを表示する

（下記の `7.0.18` はテストです）
![image](https://cloud.githubusercontent.com/assets/1885716/26812044/629b4e8e-4ab0-11e7-9ca0-4ee2ade58047.png)

### ショートコードは展開されない

![image](https://cloud.githubusercontent.com/assets/1885716/26812061/834d8bf6-4ab0-11e7-90be-e6cb5f933a45.png)
