### PR TITLE
リダイレクト URL の入力例を修正

### DIFF
--- a/templates/settings.php
+++ b/templates/settings.php
@@ -53,7 +53,7 @@
 								<img height="250" src="<?php echo $this->container['plugin_dir_url'] ?>screenshots/add_application.png" />
 							</div>
 							<p>
-								リダイレクトURLは<input class="regular-text" type="text" value="http://<?php echo $_SERVER['SERVER_NAME'] . ( 80 === $_SERVER['SERVER_PORT'] ? '' : ':' . $_SERVER['SERVER_PORT']) ?>/wp-admin/admin-ajax.php" />を入力してください。
+								リダイレクトURLは<input class="regular-text" type="text" value="<?php echo site_url() ?>/wp-admin/admin-ajax.php" />を入力してください。
 							</p>
 							<p>
 								保存後、表示される「クライアントID」「クライアントシークレット」を<br />


### PR DESCRIPTION
WordPress をサブディレクトリにインストールしている等の場合にリダイレクト URL の入力例に反映されないのを修正します。
