### PR TITLE
プラグインの認可後に真っ白画面になるのを修正

### DIFF
--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -140,21 +140,20 @@ class Admin {
 		<?php
 	}
 
-    /**
-     * wp_ajax アクションフック処理
-     *
-     * @return void
-     */
-    public function wp_ajax_colormeshop_callback()
-    {
-        $this->on_authorized();
+	/**
+	 * wp_ajax アクションフック処理
+	 *
+	 * @return void
+	 */
+	public function wp_ajax_colormeshop_callback() {
+		$this->on_authorized();
 
-        header( 'Location: ' . admin_url( '?page=' . self::MENU_SLUG ), true );
+		header( 'Location: ' . admin_url( '?page=' . self::MENU_SLUG ), true );
 
-        // return するとレスポンスボディとして '0' を返してしまうためリダイレクトできないので
-        // exit している
-        exit;
-    }
+		// return するとレスポンスボディとして '0' を返してしまうためリダイレクトできないので
+		// exit している
+		exit;
+	}
 
 	/**
 	 * OAuth 認証のコールバック処理

--- a/tests/src/class-admin-test.php
+++ b/tests/src/class-admin-test.php
@@ -9,22 +9,24 @@ class Admin_Test extends \WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->container = _get_container();
-		$this->container['token'] = function ( $c ) {
+		$this->container                  = _get_container();
+		$this->container['token']         = function ( $c ) {
 			return 'dummy';
 		};
-		$this->container['client_id'] = function ( $c ) {
+		$this->container['client_id']     = function ( $c ) {
 			return 'dummy_client_id';
 		};
 		$this->container['client_secret'] = function ( $c ) {
 			return 'dummy_client_secret';
 		};
 
-		$this->container['model.setting']->update([
-			'token' => 'dummy',
-			'client_id' => 'dummy_client_id',
-			'client_secret' => 'dummy_client_secret',
-		]);
+		$this->container['model.setting']->update(
+			[
+				'token'         => 'dummy',
+				'client_id'     => 'dummy_client_id',
+				'client_secret' => 'dummy_client_secret',
+			]
+		);
 
 		$this->container['oauth2_client'] = function ( $c ) {
 			$access_token = $this->getMockBuilder( '\League\OAuth2\Client\Token\AccessToken' )
@@ -70,7 +72,8 @@ __EOS__;
 	 * @test
 	 */
 	public function token_setting_callback() {
-		$this->expectOutputString(<<<__EOS__
+		$this->expectOutputString(
+			<<<__EOS__
 		<input type="text" id="message" name="colorme_wp_settings[token]"
 			value="dummy" class="regular-text" />
 		<br/>
@@ -84,7 +87,8 @@ __EOS__
 	 * @test
 	 */
 	public function client_id_setting_callback() {
-		$this->expectOutputString(<<<__EOS__
+		$this->expectOutputString(
+			<<<__EOS__
 		<input type="text" id="message" name="colorme_wp_settings[client_id]"
 			value="dummy_client_id" class="regular-text" /><br/>
 		
@@ -97,7 +101,8 @@ __EOS__
 	 * @test
 	 */
 	public function client_secret_setting_callback() {
-		$this->expectOutputString(<<<__EOS__
+		$this->expectOutputString(
+			<<<__EOS__
 		<input type="text" id="message" name="colorme_wp_settings[client_secret]"
 			value="dummy_client_secret" class="regular-text" /><br/>
 		


### PR DESCRIPTION
当プラグインでは、認可後のコールバックURLに admin-ajax.php を利用していて、
wp_ajaxアクションフックに登録している関数で必要な処理を行ったあと、プラグインページにリダイレクトしています。
しかし、当該フックに登録している関数で `return` するとレスポンスボディとして '0' を返す挙動になり、意図したとおりにリダイレクトされず真っ白画面になる不具合がありました 😢 