### PR TITLE
各種説明を日本語に更新

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -52,4 +52,6 @@ If you have any questions, please let me know via https://goo.gl/forms/s6zzeS3Q7
 
 == Changelog ==
 = 1.0.0 =
-* First release
+* 初回リリース
+= 1.0.1 =
+* プラグインの説明文を更新

--- a/README.txt
+++ b/README.txt
@@ -8,28 +8,44 @@ Stable tag: trunk
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-ColorMeShop WordPress Plugin helps you integrate your WP site and Ecommerce site on [ColorMeShop](https://shop-pro.jp/).
+カラーミーショップ Wordpress プラグインはWordpressでオンラインショップを構築することができるプラグインです。
 
 == Description ==
-ColorMeShop WordPress Plugin helps you integrate your WP site and Ecommerce site on [ColorMeShop](https://shop-pro.jp/) via providing the powerful features described below:
 
-* Auto-generated product page and XML sitemap
+商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordpressで行うことができます。
+なお、ご利用には[カラーミーショップ](https://shop-pro.jp/)との契約が必要です。
 
-With easy setup, the product pages and xml sitemap based on your ColorMeShop account are automatically generated on your WordPress site.
-In order to customize the layout of auto-generated product page, you can use the shortcode described at next section.
+当プラグインでは以下の機能を備えています。
 
-* Shortcodes
+### 商品ページの自動作成及びXMLサイトマップ作成機能
 
-By installing this plugin, various shortcode which obtain your product information from ColorMeShop will be available.
+カラーミーショップで登録された商品情報に基づいてWordpress上へ商品ページの自動作成とWordpressからXMLサイトマップの出力を行うことができます。
+また、商品ページは後述のショートコードを用いて商品ページのカスタマイズをすることも可能です。
 
-(Note)
-ColorMeShop WordPress Plugin needs your [developer account](https://api.shop-pro.jp/developers/sign_up)(free) as well as [ColorMeShop account](https://shop-pro.jp/) as it uses the token which belongs the account to obtain your product information via ColorMeShop API. 
+### ショートコード機能
+
+当プラグインをインストールすることで、以下の様なショートコードがご利用いただけるようになります。
+
+- 商品情報を表示用ショートコード
+- 商品画像を表示用ショートコード
+- 商品オプション表示用ショートコード
+- カートボタン表示用ショートコード
+- テンプレートにレイアウトされている商品ページ表示用ショートコード
+
+詳しくはプラグインをインストール後に表示されるメニューの説明をご覧ください。
+
+### 備考
+
+カラーミーショップWordpressプラグインの利用には[カラーミーショップ](https://shop-pro.jp/)の契約と[開発者アカウントの登録(無償)](https://api.shop-pro.jp/developers/sign_up)が必要になります。
+プラグインはカラーミーショップAPIを介してカラーミーショップで作成されたオンラインショップの商品情報を取得し、Wordpress側へ反映を行います。
 
 == Installation ==
-* WordPress dashboard
 
-1. Please search and install "ColorMeShop WordPress Plugin" from 'Plugins' menu of WordPress dashboard
-2. Activate the plugin through the 'Plugins' menu of WordPress dashboard
+Wordpressのダッシュボードより
+
+1. プラグイン＞プラグインの追加 より "colormeshop" で検索してください
+2. プラグインのメニューからプラグインを有効化してください
+3. プラグイン内の説明に従って、プラグインとカラーミーショップAPIの連携を設定してください
 
 == Frequently Asked Questions ==
 If you have any questions, please let me know via https://goo.gl/forms/s6zzeS3Q7jKDTbFO2

--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ColorMeShop Wordpress Plugin
  * Plugin URI: https://github.com/pepabo/colormeshop-wp-plugin
- * Description: ColorMeShop WordPress Plugin helps you integrate your WP site and Ecommerce site on ColorMeShop via provides auto-generated product pages, XML sitemaps and shortcodes which embeds product information into your entries.
+ * Description: カラーミーショップ Wordpress プラグインはWordpressでオンラインショップを構築することができるプラグインです。商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordpressで行うことができます。
  * Version: 1.0.0
  * Author: GMO Pepabo, Inc.
  * Author URI: https://pepabo.com/

--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: ColorMeShop Wordpress Plugin
  * Plugin URI: https://github.com/pepabo/colormeshop-wp-plugin
  * Description: カラーミーショップ Wordpress プラグインはWordpressでオンラインショップを構築することができるプラグインです。商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordpressで行うことができます。
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: GMO Pepabo, Inc.
  * Author URI: https://pepabo.com/
  * License: GPL2


### PR DESCRIPTION
- 当初、プラグイン申請のために英語で書いていたが、[(自分のプラグインであっても)多言語への翻訳が第3者によるレビュー制](https://make.wordpress.org/polyglots/handbook/tools/glotpress-translate-wordpress-org/#user%c2%a0roles-and-permissions)だということがわかった
- 初回リリースであるいまのタイミングでは、自分たちのタイミングでサッと更新したい
- カラーミーショップは現在国内需要が主なので、当該プラグインも日本語圏がターゲットになる

参照: [プラグインの作成 - WordPress Codex 日本語版](https://wpdocs.osdn.jp/%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%AE%E4%BD%9C%E6%88%90)

> 訳注: 原則として、情報はすべて英文で記載してください。ただし、日本語圏のみ配布するプラグインであれば、日本語でも構いません。

という経緯があり、README.txt 等の説明を日本語に更新します 📝 