### PR TITLE
APIクライアントを更新するコマンドを改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ $ wpcs/vendor/bin/phpcs --standard=WordPress-Core hoge.php
 $ wpcs/vendor/bin/phpcbf --standard=WordPress-Core hoge.php
 ```
 
+### APIクライアント
+
+[Swagger Codegen](https://github.com/swagger-api/swagger-codegen) で生成したAPIクライアントを利用していて、[`src/Swagger`](https://github.com/pepabo/colormeshop-wp-plugin/tree/master/src/Swagger) に配置しています。
+
+APIクライアントを更新する場合は下記のコマンドを実行してください。
+
+```bash
+# 準備
+$ brew install pipenv
+$ pipenv install
+
+# APIクライアントを生成する
+$ pipenv run fab generate_api_client
+```
+
 ### モデルやショートコードを追加したけどオートロードされない場合は
 
 [dump-autoload](https://getcomposer.org/doc/03-cli.md#dump-autoload) を実行してクラスマップを再生成してください。  

--- a/fabfile.py
+++ b/fabfile.py
@@ -44,24 +44,11 @@ def build(mode='release'):
     print('cleaning up the working directory')
     shutil.rmtree(wkdir)
 
-swagger_codegen_dir = '~/src/github.com/swagger-api/swagger-codegen/'
+def generate_api_client():
+    wkdir = tempfile.mkdtemp(dir=os.path.dirname(__file__))
+    print('working directory: ' + wkdir)
+    with lcd(wkdir):
+        local('docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli:v2.3.0 generate -i https://api.shop-pro.jp/v1/swagger.json -l php --invoker-package "ColorMeShop\Swagger" -o /local')
 
-def setup_swagger_codegen():
-    print('download swagger-codegen')
-    local('ghq get git@github.com:swagger-api/swagger-codegen.git')
-    with lcd(swagger_codegen_dir):
-        with settings(warn_only=True):
-            print('checkout v2.3.0')
-            result = local('git checkout -b 2.3.0 origin/2.3.0', capture=True)
-        if result.failed and not confirm('swagger-codegen v2.3.0 is already exists. continue anyway?'):
-            abort("aborted.")
-        local('./run-in-docker.sh mvn package')
-
-def generate_api_client(swagger_json):
-    with lcd(swagger_codegen_dir):
-        local('rm -rf SwaggerClient-php')
-        # TODO: After publishing swagger.json, use that.
-        local('cp ' + swagger_json + ' ./colormeshop_swagger.json')
-        local('./run-in-docker.sh generate -l php --invoker-package "ColorMeShop\Swagger" -i ./colormeshop_swagger.json')
-
-    local('cp -r ' + swagger_codegen_dir + 'SwaggerClient-php/lib/* src/Swagger/')
+    local('cp -R ' + wkdir + '/SwaggerClient-php/lib/ src/Swagger/')
+    local('rm -rf ' + wkdir)


### PR DESCRIPTION
Fabricを利用して、APIクライアントを生成するコマンドを用意していますが
現在、Swagger Codegenのソースをチェックアウトするかたちになっています。
（何らかの理由で v2.3.0 を使いたかったのですが、当時まだリリースされていなかったため）

現在は v2.3.0 はリリースされ、[dockerイメージ](https://hub.docker.com/r/swaggerapi/swagger-codegen-cli/tags/) も用意されていますので、これを使うように修正します 💪 

