### PR TITLE
商品IDを省略した場合の管理画面でのページ編集エラーを解消する

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -61,3 +61,5 @@ If you have any questions, please let me know via https://goo.gl/forms/s6zzeS3Q7
 * 商品画像のショートコード不具合を修正
 = 1.0.4 =
 * 商品画像のショートコード不具合を修正
+= 1.0.5 =
+* 管理画面での編集時にエラーが出る不具合を修正

--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: ColorMeShop Wordpress Plugin
  * Plugin URI: https://github.com/pepabo/colormeshop-wp-plugin
  * Description: カラーミーショップ Wordpress プラグインはWordpressでオンラインショップを構築することができるプラグインです。商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordpressで行うことができます。
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author: GMO Pepabo, Inc.
  * Author URI: https://pepabo.com/
  * License: GPL2

--- a/src/api/class-product-api.php
+++ b/src/api/class-product-api.php
@@ -47,6 +47,10 @@ class Product_Api {
 	 * @return \ColorMeShop\Swagger\Model\InlineResponse2007
 	 */
 	public function fetch( $product_id ) {
+		if ( empty($product_id) ) {
+			return [];
+		}
+
 		if ( isset( $this->caches[ $product_id ] ) ) {
 			return $this->caches[ $product_id ];
 		}

--- a/src/shortcodes/product/class-image.php
+++ b/src/shortcodes/product/class-image.php
@@ -28,6 +28,13 @@ class Image implements Shortcode_Interface {
 			$atts
 		);
 
+		if ( empty( $filtered_atts['product_id'] ) ) {
+			if ( $container['WP_DEBUG_LOG'] ) {
+				error_log( '商品IDのパラメータが不足しています. atts: ' . json_encode( $filtered_atts ) );
+			}
+			return '';
+		}
+
 		try {
 			$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
 		} catch ( ApiException $e ) {

--- a/src/shortcodes/product/class-option.php
+++ b/src/shortcodes/product/class-option.php
@@ -30,6 +30,13 @@ class Option implements Shortcode_Interface {
 			$atts
 		);
 
+		if ( empty( $filtered_atts['product_id'] ) ) {
+			if ( $container['WP_DEBUG_LOG'] ) {
+				error_log( '商品IDのパラメータが不足しています. atts: ' . json_encode( $filtered_atts ) );
+			}
+			return '';
+		}
+
 		try {
 			$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
 		} catch ( ApiException $e ) {

--- a/src/shortcodes/product/class-page.php
+++ b/src/shortcodes/product/class-page.php
@@ -37,15 +37,13 @@ class Page implements Shortcode_Interface {
 
 		if ( empty( $filtered_atts['product_id'] ) ) {
 			if ( $container['WP_DEBUG_LOG'] ) {
-				error_log( 'パラメータが不足しています. atts: ' . json_encode( $filtered_atts ) );
+				error_log( '商品IDのパラメータが不足しています. atts: ' . json_encode( $filtered_atts ) );
 			}
 			return '';
 		}
 
 		try {
-			if (isset( $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product']) ) {
-				$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
-			}
+			$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
 		} catch ( \RuntimeException $e ) {
 			if ( $container['WP_DEBUG_LOG'] ) {
 				error_log( $e );

--- a/src/shortcodes/product/class-page.php
+++ b/src/shortcodes/product/class-page.php
@@ -35,6 +35,13 @@ class Page implements Shortcode_Interface {
 			return '';
 		}
 
+		if ( empty( $filtered_atts['product_id'] ) ) {
+			if ( $container['WP_DEBUG_LOG'] ) {
+				error_log( 'パラメータが不足しています. atts: ' . json_encode( $filtered_atts ) );
+			}
+			return '';
+		}
+
 		try {
 			if (isset( $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product']) ) {
 				$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];

--- a/src/shortcodes/product/class-page.php
+++ b/src/shortcodes/product/class-page.php
@@ -36,7 +36,9 @@ class Page implements Shortcode_Interface {
 		}
 
 		try {
-			$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
+			if (isset( $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product']) ) {
+				$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
+			}
 		} catch ( \RuntimeException $e ) {
 			if ( $container['WP_DEBUG_LOG'] ) {
 				error_log( $e );


### PR DESCRIPTION
## このP/Rが解決すること
- 商品IDを省略したケースのショートコードの記述で、バージョン`5.2.3`では管理画面からのページ編集でもAPIが実行されるようになったため、ページ編集がエラーとなってしまうのを解消します
- 商品IDを省略した場合、WarningやNoticeが出るので、画面には出さず、WordPressのエラーログに詳細を出すようにします