### PR TITLE
phpcsをCIに組み込みました

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: lint
+
+on: [push]
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+
+      - run: composer install
+
+      - run: ./vendor/bin/phpcs --standard=./ruleset.xml

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ $ open http://localhost:8080
 
 ### コーディング規約
 
-PHP_CodeSniffer の WordPress 用ルールセットである [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) を利用することを推奨しています。
+PHP_CodeSniffer の WordPress 用ルールセットである [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) を利用しています。
 
-当プラグインでは上記ルールセットの [WordPress-Core](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#rulesets) に準拠していますので、Pull Request を作成される際は予め規約エラーがないことを確認してください。
+また、PHPの互換性をチェックするために、[PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility)も利用しています。
+
+これらの設定は、[ruleset.xml](./ruleset.xml)にあります。以下のコマンドで、phpcsによるチェックや自動変換を行うことができます。
 
 
 ```
-# インストール
-$ composer create-project wp-coding-standards/wpcs --no-dev
 # 規約チェック
-$ wpcs/vendor/bin/phpcs --standard=WordPress-Core hoge.php
+$ docker-compose run composer vendor/bin/phpcs --standard=ruleset.xml
 # インデントなどは自動整形できます
-$ wpcs/vendor/bin/phpcbf --standard=WordPress-Core hoge.php
+$ docker-compose run composer vendor/bin/phpcbf --standard=ruleset.xml
 ```
 
 ### APIクライアント

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
   "require-dev": {
     "phpunit/phpunit": "^5.0",
     "php-vcr/php-vcr": "^1.3",
-    "php-vcr/phpunit-testlistener-vcr": "^1.0"
+    "php-vcr/phpunit-testlistener-vcr": "^1.0",
+    "squizlabs/php_codesniffer": "*",
+    "wp-coding-standards/wpcs": "*",
+    "phpcompatibility/php-compatibility": "*",
+    "dealerdirect/phpcodesniffer-composer-installer": "*"
   },
   "autoload": {
     "classmap": ["src/"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "965bba69b57e55ec6a55b0af874eb9e5",
+    "content-hash": "1b9a1a438920b4f6f85bf70c7686df1d",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -898,6 +898,72 @@
             "time": "2018-06-11T17:15:25+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "^2|^3"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2020-01-29T20:22:20+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
             "source": {
@@ -1076,6 +1142,64 @@
             ],
             "description": "Integrates PHPUnit with PHP-VCR.",
             "time": "2016-01-12T21:15:47+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2191,6 +2315,57 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-04-17T01:09:41+00:00"
+        },
+        {
             "name": "symfony/event-dispatcher",
             "version": "v3.4.17",
             "source": {
@@ -2419,6 +2594,51 @@
                 "validate"
             ],
             "time": "2018-01-29T19:49:41+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b5a453203114cc2284b1a614c4953456fbe4f546",
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2020-02-04T02:52:06+00:00"
         }
     ],
     "aliases": [],
@@ -2430,5 +2650,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "5.6"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+  <ruleset name="ColorMeShop WordPress Plugin Rules">
+    <rule ref="WordPress-Core"/>
+    <rule ref="PHPCompatibility"/>
+
+    <config name="testVersion" value="5.6-"/>
+
+    <file>src</file>
+    <exclude-pattern>src/Swagger</exclude-pattern>
+  </ruleset>

--- a/src/api/class-product-api.php
+++ b/src/api/class-product-api.php
@@ -48,7 +48,7 @@ class Product_Api {
 	 */
 	public function fetch( $product_id ) {
 		if ( empty( $product_id ) ) {
-			return array();
+			return [];
 		}
 
 		if ( isset( $this->caches[ $product_id ] ) ) {

--- a/src/api/class-product-api.php
+++ b/src/api/class-product-api.php
@@ -48,7 +48,7 @@ class Product_Api {
 	 */
 	public function fetch( $product_id ) {
 		if ( empty( $product_id ) ) {
-			return [];
+			return array();
 		}
 
 		if ( isset( $this->caches[ $product_id ] ) ) {

--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -50,9 +50,9 @@ class Admin {
 	}
 
 	public function register() {
-		add_action( 'admin_init', [ $this, 'page_init' ] );
-		add_action( 'admin_menu', [ $this, 'add_plugin_page' ] );
-		add_action( 'wp_ajax_colormeshop_callback', [ $this, 'wp_ajax_colormeshop_callback' ] );
+		add_action( 'admin_init', array( $this, 'page_init' ) );
+		add_action( 'admin_menu', array( $this, 'add_plugin_page' ) );
+		add_action( 'wp_ajax_colormeshop_callback', array( $this, 'wp_ajax_colormeshop_callback' ) );
 	}
 
 	/**
@@ -62,10 +62,14 @@ class Admin {
 	 */
 	public function add_plugin_page() {
 		add_menu_page(
-			'カラーミーショップ', 'カラーミーショップ', 'manage_options', self::MENU_SLUG, [
+			'カラーミーショップ',
+			'カラーミーショップ',
+			'manage_options',
+			self::MENU_SLUG,
+			array(
 				$this,
 				'create_admin_page',
-			]
+			)
 		);
 	}
 
@@ -82,28 +86,44 @@ class Admin {
 		register_setting( Setting::KEY, Setting::KEY );
 		add_settings_section( 'general', '', '', self::MENU_SLUG );
 		add_settings_field(
-			'client_id', 'クライアントID', [
+			'client_id',
+			'クライアントID',
+			array(
 				$this,
 				'client_id_setting_callback',
-			], self::MENU_SLUG, 'general'
+			),
+			self::MENU_SLUG,
+			'general'
 		);
 		add_settings_field(
-			'client_secret', 'クライアントシークレット', [
+			'client_secret',
+			'クライアントシークレット',
+			array(
 				$this,
 				'client_secret_setting_callback',
-			], self::MENU_SLUG, 'general'
+			),
+			self::MENU_SLUG,
+			'general'
 		);
 		add_settings_field(
-			'token', 'トークン', [
+			'token',
+			'トークン',
+			array(
 				$this,
 				'token_setting_callback',
-			], self::MENU_SLUG, 'general'
+			),
+			self::MENU_SLUG,
+			'general'
 		);
 		add_settings_field(
-			'product_page_id', '商品ページID', [
+			'product_page_id',
+			'商品ページID',
+			array(
 				$this,
 				'pruduct_page_id_setting_callback',
-			], self::MENU_SLUG, 'general'
+			),
+			self::MENU_SLUG,
+			'general'
 		);
 	}
 
@@ -162,14 +182,15 @@ class Admin {
 	 */
 	public function on_authorized() {
 		$access_token = $this->oauth2_client->getAccessToken(
-			'authorization_code', [
+			'authorization_code',
+			array(
 				'code' => $_GET['code'],
-			]
+			)
 		);
 		$this->setting->update(
-			[
+			array(
 				'token' => $access_token->getToken(),
-			]
+			)
 		);
 	}
 }

--- a/src/class-paginator-factory.php
+++ b/src/class-paginator-factory.php
@@ -17,7 +17,7 @@ class Paginator_Factory {
 	 * @param int $current_page_no
 	 */
 	public function __construct( Url_Builder $url_builder, $current_page_no ) {
-		$this->url_builder = $url_builder;
+		$this->url_builder     = $url_builder;
 		$this->current_page_no = $current_page_no;
 	}
 

--- a/src/class-paginator.php
+++ b/src/class-paginator.php
@@ -24,9 +24,9 @@ class Paginator {
 	 */
 	public function __construct( $search_params, $response, $product_page_url, $page_name, $current_page_no ) {
 		$pager_params = array_merge(
-			[
+			array(
 				'colorme_page' => $page_name,
-			],
+			),
 			$search_params
 		);
 		unset( $pager_params['limit'] );
@@ -37,13 +37,13 @@ class Paginator {
 			$response['meta']['total'],
 			$response['meta']['limit'],
 			$current_page_no,
-			[
-				'path' => $product_page_url,
-				'query' => $pager_params,
+			array(
+				'path'     => $product_page_url,
+				'query'    => $pager_params,
 				'pageName' => 'page_no',
-			]
+			)
 		);
-		$this->response = $response;
+		$this->response  = $response;
 	}
 
 	/**

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -40,15 +40,18 @@ class Plugin {
 			$this->container['admin']->register();
 		}
 
-		add_action( 'init', [ $this, 'add_rewrite_rules' ] );
-		add_action( 'update_option_' . Setting::KEY, [ $this, 'on_update_settings' ] , 10, 2 );
-		add_filter( 'document_title_parts', [ $this, 'filter_title' ] );
-		add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
+		add_action( 'init', array( $this, 'add_rewrite_rules' ) );
+		add_action( 'update_option_' . Setting::KEY, array( $this, 'on_update_settings' ), 10, 2 );
+		add_filter( 'document_title_parts', array( $this, 'filter_title' ) );
+		add_filter( 'query_vars', array( $this, 'add_query_vars' ) );
 		add_filter( 'template_redirect', array( $this, 'handle_template_redirect' ), 1, 0 );
-		register_activation_hook( dirname( __DIR__ ) . '/colormeshop-wp-plugin.php', [
-			$this,
-			'flush_rewrite_rules',
-		] );
+		register_activation_hook(
+			dirname( __DIR__ ) . '/colormeshop-wp-plugin.php',
+			array(
+				$this,
+				'flush_rewrite_rules',
+			)
+		);
 	}
 
 	/**
@@ -58,14 +61,14 @@ class Plugin {
 	 * @return void
 	 */
 	public function add_rewrite_rules( $settings = null ) {
-		$product_page_id = ($settings && isset( $settings['product_page_id'] )) ? $settings['product_page_id'] : $this->container['model.setting']->product_page_id();
+		$product_page_id = ( $settings && isset( $settings['product_page_id'] ) ) ? $settings['product_page_id'] : $this->container['model.setting']->product_page_id();
 		if ( ! $this->container['model.setting']->is_valid_product_page_id( $product_page_id ) ) {
 			return;
 		}
 
 		// サイトマップ用のリライトルール
 		$product_page_path = str_replace( site_url(), '', get_permalink( $product_page_id ) );
-		$trimmed = trim( $product_page_path, '/' );
+		$trimmed           = trim( $product_page_path, '/' );
 		add_rewrite_rule( '^' . $trimmed . '/sitemap\.xml$', 'index.php?page_id=' . $product_page_id . '&colorme_page=sitemap', 'top' );
 	}
 
@@ -160,7 +163,7 @@ class Plugin {
 				exit;
 			}
 			// ヘッダやサイドバー等を残して、本文のみを差し替えるために the_content をフィルタする
-			add_filter( 'the_content', [ $this, 'show_categories' ] );
+			add_filter( 'the_content', array( $this, 'show_categories' ) );
 			return;
 		}
 
@@ -171,7 +174,7 @@ class Plugin {
 				include $template;
 				exit;
 			}
-			add_filter( 'the_content', [ $this, 'show_items' ] );
+			add_filter( 'the_content', array( $this, 'show_items' ) );
 			return;
 		}
 
@@ -235,7 +238,7 @@ class Plugin {
 	 */
 	private function output_sitemap_index() {
 		global $wp_query;
-		$wp_query->is_404 = false;
+		$wp_query->is_404  = false;
 		$wp_query->is_feed = true;
 
 		header( 'Content-Type:text/xml' );
@@ -257,7 +260,7 @@ class Plugin {
 	 */
 	private function output_sitemap( $offset ) {
 		global $wp_query;
-		$wp_query->is_404 = false;
+		$wp_query->is_404  = false;
 		$wp_query->is_feed = true;
 
 		header( 'Content-Type:text/xml' );
@@ -292,11 +295,13 @@ class Plugin {
 		};
 
 		$container['oauth2_client'] = function ( $c ) {
-			return new OAuth2Client( [
-				'clientId'     => $c['model.setting']->client_id(),
-				'clientSecret' => $c['model.setting']->client_secret(),
-				'redirectUri'  => admin_url( 'admin-ajax.php?action=colormeshop_callback' ),
-			] );
+			return new OAuth2Client(
+				array(
+					'clientId'     => $c['model.setting']->client_id(),
+					'clientSecret' => $c['model.setting']->client_secret(),
+					'redirectUri'  => admin_url( 'admin-ajax.php?action=colormeshop_callback' ),
+				)
+			);
 		};
 
 		$container['target_id'] = function ( $c ) {
@@ -370,14 +375,14 @@ class Plugin {
 		};
 
 		$shortcode_invoker = new Shortcode_Invoker( $this->container );
-		$classmap = include( __DIR__ . '/../vendor/composer/autoload_classmap.php' );
+		$classmap          = include( __DIR__ . '/../vendor/composer/autoload_classmap.php' );
 		foreach ( $classmap as $class => $path ) {
 			if ( strpos( $path, dirname( __DIR__ ) . '/src/shortcodes/' ) !== 0 ) {
 				continue;
 			}
 			add_shortcode(
-				call_user_func( [ $class, 'name' ] ),
-				[ $shortcode_invoker, $to_invoker_methodname( $class ) ]
+				call_user_func( array( $class, 'name' ) ),
+				array( $shortcode_invoker, $to_invoker_methodname( $class ) )
 			);
 		}
 	}

--- a/src/class-shortcode-invoker.php
+++ b/src/class-shortcode-invoker.php
@@ -23,6 +23,6 @@ class Shortcode_Invoker {
 		array_unshift( $arguments, $this->container );
 		$class = str_replace( '_', '\\', $name );
 
-		return call_user_func_array( [ $class, 'show' ], $arguments );
+		return call_user_func_array( array( $class, 'show' ), $arguments );
 	}
 }

--- a/src/class-url-builder.php
+++ b/src/class-url-builder.php
@@ -32,14 +32,14 @@ class Url_Builder {
 	 * @param array $params
 	 * @return string
 	 */
-	public function items( $params = [] ) {
+	public function items( $params = array() ) {
 		if ( $this->product_page_has_query() ) {
 			$items_url = $this->product_page_permalink() . '&colorme_page=items';
 		} else {
 			$items_url = trim( $this->product_page_permalink(), '/' ) . '/?colorme_page=items';
 		}
 
-		return $items_url . ( ($params) ? '&' . http_build_query( $params ) : '');
+		return $items_url . ( ( $params ) ? '&' . http_build_query( $params ) : '' );
 	}
 
 	/**
@@ -66,10 +66,10 @@ class Url_Builder {
 	 */
 	public function sitemap( $offset = null ) {
 		if ( $this->product_page_has_query() ) {
-			return $this->product_page_permalink() . '&colorme_page=sitemap' . ((null === $offset) ? '' : '&offset=' . $offset);
+			return $this->product_page_permalink() . '&colorme_page=sitemap' . ( ( null === $offset ) ? '' : '&offset=' . $offset );
 		}
 
-		return trim( $this->product_page_permalink(), '/' ) . '/sitemap.xml' . ((null === $offset) ? '' : '?offset=' . $offset);
+		return trim( $this->product_page_permalink(), '/' ) . '/sitemap.xml' . ( ( null === $offset ) ? '' : '?offset=' . $offset );
 	}
 
 	/**

--- a/src/models/class-setting.php
+++ b/src/models/class-setting.php
@@ -11,7 +11,7 @@ class Setting {
 	 */
 	public function get( $name = null ) {
 		$setting = get_option( self::KEY );
-		if ( $name === null ) {
+		if ( is_null( $name ) ) {
 			return $setting ? $setting : array();
 		}
 

--- a/src/models/class-setting.php
+++ b/src/models/class-setting.php
@@ -12,7 +12,7 @@ class Setting {
 	public function get( $name = null ) {
 		$setting = get_option( self::KEY );
 		if ( $name === null ) {
-			return $setting ? $setting : [];
+			return $setting ? $setting : array();
 		}
 
 		return $setting && array_key_exists( $name, $setting ) ? $setting[ $name ] : '';

--- a/src/models/class-sitemap.php
+++ b/src/models/class-sitemap.php
@@ -34,8 +34,8 @@ class Sitemap {
 	 */
 	public function __construct( $product_api, $url ) {
 		$this->product_api = $product_api;
-		$this->url = $url;
-		$this->sitemap = new S();
+		$this->url         = $url;
+		$this->sitemap     = new S();
 	}
 
 	/**
@@ -46,7 +46,7 @@ class Sitemap {
 	 */
 	public function generate_index() {
 		$sitemap_index = new SitemapIndex;
-		$total = $this->product_api->total();
+		$total         = $this->product_api->total();
 
 		for ( $i = 0; $i <= $total; $i += self::NUMBER_OF_ITEM_URLS_PER_PAGE ) {
 			$sitemap_index->add( $this->url->sitemap( $i ), null );

--- a/src/shortcodes/cart/class-button.php
+++ b/src/shortcodes/cart/class-button.php
@@ -20,10 +20,10 @@ class Button implements Shortcode_Interface {
 	 */
 	public static function show( $container, $atts, $content, $tag ) {
 		$filtered_atts = shortcode_atts(
-			[
+			array(
 				'product_id' => $container['target_id'],
-				'style' => 'basic',
-			],
+				'style'      => 'basic',
+			),
 			$atts
 		);
 

--- a/src/shortcodes/class-product.php
+++ b/src/shortcodes/class-product.php
@@ -26,10 +26,10 @@ class Product implements Shortcode_Interface {
 	 */
 	public static function show( $container, $atts, $content, $tag ) {
 		$filtered_atts = shortcode_atts(
-			[
+			array(
 				'product_id' => $container['target_id'],
-				'data' => null,
-			],
+				'data'       => null,
+			),
 			$atts
 		);
 
@@ -43,8 +43,8 @@ class Product implements Shortcode_Interface {
 		if ( method_exists( self::class, '_' . $filtered_atts['data'] ) ) {
 			try {
 				return call_user_func_array(
-					[ self::class, '_' . $filtered_atts['data'] ],
-					[ $container, $filtered_atts, $content, $tag ]
+					array( self::class, '_' . $filtered_atts['data'] ),
+					array( $container, $filtered_atts, $content, $tag )
 				);
 			} catch ( ApiException $e ) {
 				if ( $container['WP_DEBUG_LOG'] ) {

--- a/src/shortcodes/product/class-image.php
+++ b/src/shortcodes/product/class-image.php
@@ -21,10 +21,10 @@ class Image implements Shortcode_Interface {
 	 */
 	public static function show( $container, $atts, $content, $tag ) {
 		$filtered_atts = shortcode_atts(
-			[
+			array(
 				'product_id' => $container['target_id'],
-				'type' => 'main',
-			],
+				'type'       => 'main',
+			),
 			$atts
 		);
 
@@ -99,10 +99,13 @@ class Image implements Shortcode_Interface {
 	 * @return array
 	 */
 	private static function extract_other_images( $product ) {
-	    // その他画像のリストからフィーチャーフォン版用画像を取り除く
-		$filtered_images = array_filter($product['images'], function ( $image ) {
-			return ! $image['mobile'];
-		});
+		// その他画像のリストからフィーチャーフォン版用画像を取り除く
+		$filtered_images = array_filter(
+			$product['images'],
+			function ( $image ) {
+				return ! $image['mobile'];
+			}
+		);
 
 		return array_values( $filtered_images );
 	}
@@ -115,7 +118,7 @@ class Image implements Shortcode_Interface {
 	 * @return string
 	 */
 	private static function extract_other_image( $container, $filtered_atts ) {
-		$index = self::extract_other_image_index( $filtered_atts['type'] );
+		$index        = self::extract_other_image_index( $filtered_atts['type'] );
 		$other_images = self::extract_other_images(
 			$container['api.product_api']->fetch( $filtered_atts['product_id'] )['product']
 		);

--- a/src/shortcodes/product/class-option.php
+++ b/src/shortcodes/product/class-option.php
@@ -22,11 +22,11 @@ class Option implements Shortcode_Interface {
 	 */
 	public static function show( $container, $atts, $content, $tag ) {
 		$filtered_atts = shortcode_atts(
-			[
+			array(
 				'product_id' => $container['target_id'],
-				'index' => 1,
-				'data' => 'title',
-			],
+				'index'      => 1,
+				'data'       => 'title',
+			),
 			$atts
 		);
 

--- a/src/shortcodes/product/class-page.php
+++ b/src/shortcodes/product/class-page.php
@@ -20,10 +20,10 @@ class Page implements Shortcode_Interface {
 	 */
 	public static function show( $container, $atts, $content, $tag ) {
 		$filtered_atts = shortcode_atts(
-			[
+			array(
 				'product_id' => $container['target_id'],
-				'template' => 'default',
-			],
+				'template'   => 'default',
+			),
 			$atts
 		);
 		$template_file = $container['templates_dir'] . '/product/' . $filtered_atts['template'] . '.php';


### PR DESCRIPTION
phpcsを使ったコーディング規約チェックをコンテナ内で実行できるようにして、GitHub Actionsでも回すようにしました。

規約は以下の2つを入れています。

- WordPress-Core
- PHPCompatibility (設定でPHP5.6以上)

https://github.com/pepabo/colormeshop-wp-plugin/commit/729533064e444db1f1fa0a10ccd886ec5336d4de のコミットであえてチェックされるコードを入れて、GitHub Actionsで落ちることを確認しました。

また、既存のコードの多くがコーディング規約に引っかかるものだったので、合わせて修正しました。