### PR TITLE
Enable GitHub Actions CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '7.3'
           tools: composer
 
       - run: composer install

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,5 +40,5 @@ jobs:
 
       - run: composer install
 
-      - run: bin/install-wp-tests.sh test root root-password mysql
+      - run: bin/install-wp-tests.sh test root root-password mysql:${{ job.services.mysql.ports['3306'] }}
       - run: ./vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8
+        image: mysql:5
         env:
           MYSQL_ROOT_PASSWORD: root-password
         ports:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,3 +17,28 @@ jobs:
       - run: composer install
 
       - run: ./vendor/bin/phpcs --standard=./ruleset.xml
+
+  phpunit:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root-password
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.3'
+          tools: composer
+
+      - run: composer install
+
+      - run: bin/install-wp-tests.sh test root root-password mysql
+      - run: ./vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.3'
+          extensions: mysqli
           tools: composer
 
       - run: composer install

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,5 +40,5 @@ jobs:
 
       - run: composer install
 
-      - run: bin/install-wp-tests.sh test root root-password mysql:${{ job.services.mysql.ports['3306'] }}
+      - run: bin/install-wp-tests.sh test root root-password 127.0.0.1:${{ job.services.mysql.ports['3306'] }}
       - run: ./vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: lint
+name: php
 
 on: [push]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:php7.4
+FROM wordpress:php7.3
 
 RUN apt-get update \
  && apt-get -y install subversion \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 services:
   wordpress:
     build: .
-    container_name: "colormeshop_wp_plugin_wordpress"
     ports:
       - 8080:80
     env_file: wp.env
@@ -12,6 +11,8 @@ services:
       - vendor_data:/var/www/html/wp-content/plugins/colormeshop-wp-plugin/vendor
     depends_on:
       - composer
+      - mysql
+    links:
       - mysql
 
   composer:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-source ./wp.env
-docker exec -i colormeshop_wp_plugin_wordpress bash -c "cd /var/www/html/wp-content/plugins/colormeshop-wp-plugin \
-&& ./bin/install-wp-tests.sh unit_test root $MYSQL_ROOT_PASSWORD mysql \
-&& ./vendor/bin/phpunit"
+docker-compose run --rm wordpress bash -c "cd /var/www/html/wp-content/plugins/colormeshop-wp-plugin \
+&& ./bin/install-wp-tests.sh unit_test root \$MYSQL_ROOT_PASSWORD mysql \
+|| ./vendor/bin/phpunit"

--- a/tests/src/class-plugin-test.php
+++ b/tests/src/class-plugin-test.php
@@ -45,6 +45,7 @@ class Plugin_Test extends \WP_UnitTestCase {
 #
 __EOS__;
 		$this->expectOutputRegex( $regex );
+		the_post();
 		the_content();
 	}
 
@@ -76,6 +77,7 @@ __EOS__;
 #
 __EOS__;
 		$this->expectOutputRegex( $regex );
+		the_post();
 		the_content();
 	}
 


### PR DESCRIPTION
GitHub Actionsでphpunitを実行できるようにしました。注意点は以下の2点です。

- php-vcrのphp 7.4対応が終わっていないので、PHPのバージョンは7.3にしてあります。
- wpdbでcaching_sha2_passwordに対応する方法がわからなかったので、MySQLは5系を使っています。