### PR TITLE
CIを実行するタイミングを変更する

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,12 @@
 name: php
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   phpcs:


### PR DESCRIPTION
#111 にて、pushイベントだけの場合は、forkされたときにCIが動かないことがわかった。

そのため、masterへのPull Reqeustと、masterへのpushでCIが動くようにした。