### PR TITLE
1.0.6をstableとして、2.0への準備を始めます

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, ec, colormeshop
 Requires at least: 4.6
 Tested up to: 4.9.6
 Requires PHP: 5.6.0
-Stable tag: trunk
+Stable tag: tags/1.0.6
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
ref: #113 

README.txtでStable tagを指定することで、 #109 のテストや2.0.0系に向けた検証を利用者への影響を最小限にできるようにします。