### PR TITLE
Resplace illuminate/paginate with WP paginate_links function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "guzzlehttp/guzzle": "^6.3",
     "pepabo/oauth2-colormeshop": "^1.0",
     "pimple/pimple": "~3.0",
-    "tackk/cartographer": "1.1.*",
-    "illuminate/pagination": "5.2.45"
+    "tackk/cartographer": "1.1.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,75 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52395573575e5a90878a4c058094ae52",
+    "content-hash": "96104d1852d5f9781dd8cf6b2dcb224b",
     "packages": [
-        {
-            "name": "doctrine/inflector",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/inflector.git",
-                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
-                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
-            "homepage": "http://www.doctrine-project.org",
-            "keywords": [
-                "inflection",
-                "pluralize",
-                "singularize",
-                "string"
-            ],
-            "time": "2019-10-30T19:59:35+00:00"
-        },
         {
             "name": "guzzlehttp/guzzle",
             "version": "6.5.3",
@@ -263,151 +196,6 @@
             "time": "2019-07-01T23:21:34+00:00"
         },
         {
-            "name": "illuminate/contracts",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/contracts.git",
-                "reference": "22bde7b048a33c702d9737fc1446234fff9b1363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/22bde7b048a33c702d9737fc1446234fff9b1363",
-                "reference": "22bde7b048a33c702d9737fc1446234fff9b1363",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Contracts\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Contracts package.",
-            "homepage": "http://laravel.com",
-            "time": "2016-08-08T11:46:08+00:00"
-        },
-        {
-            "name": "illuminate/pagination",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/pagination.git",
-                "reference": "a4450887251f443a1243ef537d98ce5bbea6b193"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/pagination/zipball/a4450887251f443a1243ef537d98ce5bbea6b193",
-                "reference": "a4450887251f443a1243ef537d98ce5bbea6b193",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/contracts": "5.2.*",
-                "illuminate/support": "5.2.*",
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Pagination\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Pagination package.",
-            "homepage": "http://laravel.com",
-            "time": "2016-08-01T13:49:14+00:00"
-        },
-        {
-            "name": "illuminate/support",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/support.git",
-                "reference": "510230ab62a7d85dc70203f4fdca6fb71a19e08a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/510230ab62a7d85dc70203f4fdca6fb71a19e08a",
-                "reference": "510230ab62a7d85dc70203f4fdca6fb71a19e08a",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/inflector": "~1.0",
-                "ext-mbstring": "*",
-                "illuminate/contracts": "5.2.*",
-                "paragonie/random_compat": "~1.4",
-                "php": ">=5.5.9"
-            },
-            "replace": {
-                "tightenco/collect": "self.version"
-            },
-            "suggest": {
-                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
-                "jeremeamia/superclosure": "Required to be able to serialize closures (~2.2).",
-                "symfony/polyfill-php56": "Required to use the hash_equals function on PHP 5.5 (~1.0).",
-                "symfony/process": "Required to use the composer class (2.8.*|3.0.*).",
-                "symfony/var-dumper": "Improves the dd function (2.8.*|3.0.*)."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Support\\": ""
-                },
-                "files": [
-                    "helpers.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Support package.",
-            "homepage": "http://laravel.com",
-            "time": "2016-08-05T14:49:58+00:00"
-        },
-        {
             "name": "league/flysystem",
             "version": "1.0.67",
             "source": {
@@ -560,33 +348,29 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v1.4.3",
+            "version": "v9.99.99",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "9b3899e3c3ddde89016f576edb8c489708ad64cd"
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/9b3899e3c3ddde89016f576edb8c489708ad64cd",
-                "reference": "9b3899e3c3ddde89016f576edb8c489708ad64cd",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.0"
+                "php": "^7"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
             },
             "suggest": {
                 "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
             },
             "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -601,10 +385,11 @@
             "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
             "keywords": [
                 "csprng",
+                "polyfill",
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-04-04T21:48:54+00:00"
+            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "pepabo/oauth2-colormeshop",
@@ -3199,5 +2984,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/src/class-paginator.php
+++ b/src/class-paginator.php
@@ -1,14 +1,17 @@
 <?php
 namespace ColorMeShop;
 
-use Illuminate\Pagination\LengthAwarePaginator;
-
 class Paginator {
 
 	/**
-	 * @var LengthAwarePaginator
+	 * @var int
 	 */
-	private $paginator;
+	private $total_pages;
+
+	/**
+	 * @var int
+	 */
+	private $current_page;
 
 	/**
 	 * @var array
@@ -23,41 +26,32 @@ class Paginator {
 	 * @param int $current_page_no
 	 */
 	public function __construct( $search_params, $response, $product_page_url, $page_name, $current_page_no ) {
-		$pager_params = array_merge(
-			array(
-				'colorme_page' => $page_name,
-			),
-			$search_params
-		);
-		unset( $pager_params['limit'] );
-		unset( $pager_params['offset'] );
-
-		$this->paginator = new LengthAwarePaginator(
-			$response['products'],
-			$response['meta']['total'],
-			$response['meta']['limit'],
-			$current_page_no,
-			array(
-				'path'     => $product_page_url,
-				'query'    => $pager_params,
-				'pageName' => 'page_no',
-			)
-		);
-		$this->response  = $response;
+		$this->total_pages  = ceil( $response['meta']['total'] / $response['meta']['limit'] );
+		$this->current_page = is_numeric( $current_page_no ) ? intval( $current_page_no ) : 1;
+		$this->response     = $response;
 	}
 
 	/**
 	 * @return string
 	 */
 	public function links() {
-		return $this->paginator->links();
+		return paginate_links(
+			array(
+				'total'     => $this->total_pages,
+				'current'   => $this->current_page,
+				'format'    => '?page_no=%#%',
+				'prev_text' => '&laquo;',
+				'next_text' => '&raquo;',
+				'type'      => 'list',
+			)
+		);
 	}
 
 	/**
 	 * @return array
 	 */
 	public function data() {
-		return $this->paginator->toArray()['data'];
+		return $this->response['products'];
 	}
 
 	/**

--- a/tests/src/class-paginator-test.php
+++ b/tests/src/class-paginator-test.php
@@ -37,7 +37,17 @@ class Paginator_Test extends \WP_UnitTestCase {
 	 */
 	public function links() {
 		$expected = <<<__EOS__
-<ul class="pagination"><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=1" rel="prev">&laquo;</a></li> <li><a href="https://example.com/shop?colorme_page=items&amp;page_no=1">1</a></li><li class="active"><span>2</span></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=3">3</a></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=4">4</a></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=5">5</a></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=6">6</a></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=7">7</a></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=8">8</a></li><li class="disabled"><span>...</span></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=999">999</a></li><li><a href="https://example.com/shop?colorme_page=items&amp;page_no=1000">1000</a></li> <li><a href="https://example.com/shop?colorme_page=items&amp;page_no=3" rel="next">&raquo;</a></li></ul>
+<ul class='page-numbers'>
+	<li><a class="prev page-numbers" href="http://example.org/">&laquo;</a></li>
+	<li><a class="page-numbers" href="http://example.org/">1</a></li>
+	<li><span aria-current="page" class="page-numbers current">2</span></li>
+	<li><a class="page-numbers" href="http://example.org/?page_no=3">3</a></li>
+	<li><a class="page-numbers" href="http://example.org/?page_no=4">4</a></li>
+	<li><span class="page-numbers dots">&hellip;</span></li>
+	<li><a class="page-numbers" href="http://example.org/?page_no=1000">1,000</a></li>
+	<li><a class="next page-numbers" href="http://example.org/?page_no=3">&raquo;</a></li>
+</ul>
+
 __EOS__;
 
 		$this->assertSame( $expected, (string) $this->paginator->links() );


### PR DESCRIPTION
close #121 

illuminate/paginateを5.3以上にするための調査をしていましたが、Laravelのサービスコンテナへの依存が強くなっており、単体で利用するのは困難だと判断しました。

そのため、似たようなことができるWordPressの関数 [paginate\_links\(\) \| Function \| WordPress Developer Resources](https://developer.wordpress.org/reference/functions/paginate_links/) を使って実装しなおしました。

今までと似たHTMLが出力されるようにしましたが、完全に同じものを出力するのは困難だったので、非互換な変更になります。

v1系にはバックポートせず、v2系にのみこの変更を入れたいです。