### PR TITLE
Fix an error in the CI workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,6 +48,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: mysqli
           tools: composer
+          coverage: xdebug
 
       - run: composer install
 


### PR DESCRIPTION
https://github.com/pepabo/colormeshop-wp-plugin/pull/138/checks?check_run_id=1575450438
> Code coverage needs to be enabled in php.ini by setting 'xdebug.mode' to 'coverage'


We could use `coverage: xdebug` to fix the error. 🚀 
ref: https://github.com/shivammathur/setup-php#xdebug
