### PR TITLE
カラーミーAPIがOpenAPI v3の記法に変わったためswagger-codegen-cliをv3に切り換える

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: generate_api_client
 generate_api_client:
-	docker run --rm -v $(CURDIR)/src/Swagger/:/local/SwaggerClient-php/lib/ swaggerapi/swagger-codegen-cli:v2.3.0 generate -i https://api.shop-pro.jp/v1/swagger.json -l php --invoker-package "ColorMeShop\Swagger" -o /local
+	docker run --rm -v $(CURDIR)/src/Swagger/:/local/SwaggerClient-php/lib/ swaggerapi/swagger-codegen-cli-v3:3.0.27 generate -i https://api.shop-pro.jp/v1/swagger.json -l php --invoker-package "ColorMeShop\Swagger" -o /local
 
 .PHONY: build_builder_container
 build_builder_container:


### PR DESCRIPTION
カラーミーショップAPIは現在OpenAPI v3の記法となっており、
現状のswagger-codegen-cliではコードの自動生成が行えなくなっていたため修正する。

https://api.shop-pro.jp/v1/spec/open_api.json
```
  "openapi": "3.0.2",
```

Imageは下記のURLより一番新しいバージョンを選択した
https://hub.docker.com/r/swaggerapi/swagger-codegen-cli-v3/tags?page=1&ordering=last_updated