### PR TITLE
release v3.0.0

### DIFF
--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: ColorMeShop WordPress Plugin
  * Plugin URI: https://github.com/pepabo/colormeshop-wp-plugin
  * Description: カラーミーショップ WordPress プラグインはWordPressでオンラインショップを構築することができるプラグインです。商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordPressで行うことができます。
- * Version: 2.0.0
+ * Version: 3.0.0
  * Author: GMO Pepabo, Inc.
  * Author URI: https://pepabo.com/
  * License: GPL2


### PR DESCRIPTION
参考PR https://github.com/pepabo/colormeshop-wp-plugin/pull/135

pluginファイルを更新してv3.0.0をリリースできるようにします。
このブランチをマージした後、gitのv3.0.0タグをpushするとリリースされます。