### PR TITLE
release v2.0.1

### DIFF
--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: ColorMeShop WordPress Plugin
  * Plugin URI: https://github.com/pepabo/colormeshop-wp-plugin
  * Description: カラーミーショップ WordPress プラグインはWordPressでオンラインショップを構築することができるプラグインです。商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordPressで行うことができます。
- * Version: 3.0.0
+ * Version: 2.0.1
  * Author: GMO Pepabo, Inc.
  * Author URI: https://pepabo.com/
  * License: GPL2

--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: ColorMeShop WordPress Plugin
  * Plugin URI: https://github.com/pepabo/colormeshop-wp-plugin
  * Description: カラーミーショップ WordPress プラグインはWordPressでオンラインショップを構築することができるプラグインです。商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordPressで行うことができます。
- * Version: 2.0.0
+ * Version: 3.0.0
  * Author: GMO Pepabo, Inc.
  * Author URI: https://pepabo.com/
  * License: GPL2


### PR DESCRIPTION
https://github.com/pepabo/colormeshop-wp-plugin/pull/146
https://github.com/pepabo/colormeshop-wp-plugin/pull/147
APIクライアントを最新に切り換え一部プランで利用できないバグを修正します。

pluginファイルを更新してv2.0.1をリリースできるようにします。