### PR TITLE
Tested up toのバージョンを5.8.1に書き換え

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: colormeshop
 Tags: ecommerce, ec, colormeshop
 Requires at least: 5.2
-Tested up to: 5.5.1
+Tested up to: 5.8.1
 Requires PHP: 7.3.0
 Stable tag: trunk
 License: GPLv2


### PR DESCRIPTION
プラグインページの対応する最新バージョンに表示される
バージョン番号を最新のものに差し替えます。