### PR TITLE
release v2.0.2

### DIFF
--- a/colormeshop-wp-plugin.php
+++ b/colormeshop-wp-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: ColorMeShop WordPress Plugin
  * Plugin URI: https://github.com/pepabo/colormeshop-wp-plugin
  * Description: カラーミーショップ WordPress プラグインはWordPressでオンラインショップを構築することができるプラグインです。商品管理やショッピングカートの機能はカラーミーショップを利用することで、本格的なオンラインショップ構築をWordPressで行うことができます。
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: GMO Pepabo, Inc.
  * Author URI: https://pepabo.com/
  * License: GPL2


### PR DESCRIPTION
https://github.com/pepabo/colormeshop-wp-plugin/pull/150
プラグインページの対応する最新バージョンに表示される
バージョン番号を5.8.1に差し替え

pluginファイルを更新してv2.0.2をリリースできるようにします。