### PR TITLE
Tested up toのバージョンを6.4.2に書き換え

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: colormeshop
 Tags: ecommerce, ec, colormeshop
 Requires at least: 5.2
-Tested up to: 5.8.1
+Tested up to: 6.4.2
 Requires PHP: 7.3.0
 Stable tag: trunk
 License: GPLv2


### PR DESCRIPTION
プラグインページの対応する最新バージョンに表示される
検証で確認が取れたバージョンに差し替えます。

検証で利用したWordPress
<img width="431" alt="image" src="https://github.com/pepabo/colormeshop-wp-plugin/assets/1719979/9aed6a79-4abb-4176-a7a6-b137b9a0c3ed">
