### PR TITLE
Page クラスのショートコードの例外処理で、 \ColorMeShop\Swagger\ApiExceptionがcatchされるようにする

### DIFF
--- a/src/shortcodes/product/class-page.php
+++ b/src/shortcodes/product/class-page.php
@@ -44,6 +44,11 @@ class Page implements Shortcode_Interface {
 
 		try {
 			$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
+		} catch ( \ColorMeShop\Swagger\ApiException $e ) {
+			if ( $container['WP_DEBUG_LOG'] ) {
+				error_log( $e );
+			}
+			return '';
 		} catch ( \RuntimeException $e ) {
 			if ( $container['WP_DEBUG_LOG'] ) {
 				error_log( $e );

--- a/src/shortcodes/product/class-page.php
+++ b/src/shortcodes/product/class-page.php
@@ -46,7 +46,7 @@ class Page implements Shortcode_Interface {
 			$product = $container['api.product_api']->fetch( $filtered_atts['product_id'] )['product'];
 		} catch ( \ColorMeShop\Swagger\ApiException $e ) {
 			if ( $container['WP_DEBUG_LOG'] ) {
-				error_log( $e );
+				error_log( '存在しない商品IDが指定された可能性があります。' . $e );
 			}
 			return '';
 		} catch ( \RuntimeException $e ) {

--- a/tests/src/shortcodes/product/class-page-test.php
+++ b/tests/src/shortcodes/product/class-page-test.php
@@ -2,6 +2,34 @@
 namespace ColorMeShop\Shortcodes\Product;
 
 class Page_Test extends \WP_UnitTestCase {
+
+	/** @var \Pimple\Container */
+	private $container;
+
+	/** @var string */
+	private $error_log;
+
+	/** @var string */
+	private $original_error_log;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->container = _get_container();
+		$this->container['token'] = function ( $c ) {
+			return 'dummy';
+		};
+
+		// ログ出力先
+		$this->error_log = tempnam( sys_get_temp_dir(), 'TEST' );
+		$this->original_error_log = ini_set( 'error_log', $this->error_log );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		ini_set( 'error_log', $this->original_error_log );
+	}
+
 	/**
 	 * @test
 	 */
@@ -29,30 +57,26 @@ class Page_Test extends \WP_UnitTestCase {
 	/**
 	 * @test
 	 */
-	public function show_存在しない商品IDが指定された場合は、ApiExceptionをcatchし空文字を返す() {
-		$container = $this->createMock(\Pimple\Container::class);
-		$product_api = $this->createMock(\ColorMeShop\Swagger\Api\ProductApi::class);
+	public function show_存在しない商品IDが指定された場合、デバッグが有効であればエラーメッセージを出力し、空文字を返す() {
+		$this->container['WP_DEBUG_LOG'] = function ( $c ) {
+			return true;
+		};
 
-		$product_api->method('fetch')
-			->willThrowException(new \ColorMeShop\Swagger\ApiException());
-
-		$container->method('offsetGet')
-			->willReturnMap([
-				['api.product_api', $product_api],
-				['WP_DEBUG_LOG', false],
-			]);
-
+		$pageShow = Page::show(
+			$this->container,
+			[
+				'template' => 'default',
+				'product_id' => '00000000',
+			],
+			null,
+			null
+		);
+		
 		$this->assertSame(
 			'',
-			Page::show(
-				$container,
-				[
-					'template' => 'default',
-					'product_id' => '999999', // 存在しない商品ID
-				],
-				null,
-				null
-			)
+			$pageShow
 		);
+
+		$this->assertStringContainsString( '存在しない商品IDが指定された可能性があります。',  file_get_contents( $this->error_log ) );
 	}
 }

--- a/tests/src/shortcodes/product/class-page-test.php
+++ b/tests/src/shortcodes/product/class-page-test.php
@@ -25,4 +25,34 @@ class Page_Test extends \WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+	 * @test
+	 */
+	public function show_存在しない商品IDが指定された場合は、ApiExceptionをcatchし空文字を返す() {
+		$container = $this->createMock(\Pimple\Container::class);
+		$product_api = $this->createMock(\ColorMeShop\Swagger\Api\ProductApi::class);
+
+		$product_api->method('fetch')
+			->willThrowException(new \ColorMeShop\Swagger\ApiException());
+
+		$container->method('offsetGet')
+			->willReturnMap([
+				['api.product_api', $product_api],
+				['WP_DEBUG_LOG', false],
+			]);
+
+		$this->assertSame(
+			'',
+			Page::show(
+				$container,
+				[
+					'template' => 'default',
+					'product_id' => '999999', // 存在しない商品ID
+				],
+				null,
+				null
+			)
+		);
+	}
 }

--- a/tests/src/shortcodes/product/class-page-test.php
+++ b/tests/src/shortcodes/product/class-page-test.php
@@ -16,10 +16,6 @@ class Page_Test extends \WP_UnitTestCase {
 		parent::setUp();
 
 		$this->container = _get_container();
-		$this->container['token'] = function ( $c ) {
-			return 'dummy';
-		};
-
 		// ログ出力先
 		$this->error_log = tempnam( sys_get_temp_dir(), 'TEST' );
 		$this->original_error_log = ini_set( 'error_log', $this->error_log );


### PR DESCRIPTION
https://github.com/pepabo/colormeshop-wp-plugin/issues/166
の問題を解消するためのPRです。

削除済みの商品IDを指定した際の例外処理が適切ではないので、 \ColorMeShop\Swagger\ApiException をcatchしてエラーハンドリングが正しく行われるように修正します。

 \ColorMeShop\Swagger\ApiException が発生した際、原因が特定しやすくするよう、error_log内に発生原因として考えられるメッセージを入れました。

## レビューポイント
- error_logに含めたメッセージ内容が良さそうか